### PR TITLE
Fixed Build on Debian Linux

### DIFF
--- a/src/LeydenJarDiagnosticTool.h
+++ b/src/LeydenJarDiagnosticTool.h
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <vector>
+#include <string>
 #include "LeydenJarAgent.h"
 #include "imgui.h"
 


### PR DESCRIPTION
This program would not build on Debian Linux because in one of the header files, std::string was used without including <string>. While this works in MSVC, G++ complains that it doesn't know what that type is at link time. Including the header is the safe and correct thing to do, which this PR does.